### PR TITLE
Add prefix-suffix matrix helper

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -52,6 +52,18 @@ OEIS sequence analysis and validation.
 
 Prime number generation and dataset creation.
 
+`PrimeCSVGenerator` exposes a helper `generate_prefix_suffix_dataset()` that
+wraps ``generate_prefix_suffix_matrix`` from ``src.utils``.  It allows building
+custom prefix-suffix matrices from any list of numbers.
+
+```python
+from src.generators.prime_generator import PrimeCSVGenerator
+
+gen = PrimeCSVGenerator()
+gen.load_primes()
+df = gen.generate_prefix_suffix_dataset(prefix_digits=2, suffix_digits=2)
+```
+
 ### sequence_generator
 
 General mathematical sequence generation.

--- a/src/generators/prime_generator.py
+++ b/src/generators/prime_generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
 Prime CSV Generator - Multiple Dataset Formats
+Provides utilities to build prefix-suffix matrices from arbitrary number sets.
 Reads 1m.csv containing prime numbers and generates four different CSV formats
 based on different mathematical insights about prime number patterns.
 """
@@ -17,6 +18,7 @@ import os
 import sys
 from pathlib import Path
 import time
+from src.utils.prefix_suffix_utils import generate_prefix_suffix_matrix
 
 
 class PrimeGenerator:
@@ -29,6 +31,7 @@ class PrimeGenerator:
         raise NotImplementedError
 
 class PrimeCSVGenerator:
+    """CSV utilities for prime data generation. Includes helpers for building prefix-suffix matrices."""
     def __init__(self, input_file="../../data/raw/1m.csv", output_dir="output"):
         """
         Initialize the Prime CSV Generator
@@ -300,6 +303,32 @@ class PrimeCSVGenerator:
         self.save_matrix_to_csv(
             df, filename, "Dataset 3 - Extended Prime-Friendly Endings"
         )
+        return df
+
+    def generate_prefix_suffix_dataset(
+        self,
+        prefix_digits: int,
+        suffix_digits: int,
+        numbers: list[int] | None = None,
+    ):
+        """Generate a prefix-suffix matrix using the loaded primes.
+
+        Parameters
+        ----------
+        prefix_digits:
+            Number of leading digits to treat as the prefix.
+        suffix_digits:
+            Number of trailing digits to use as the suffix.
+        numbers:
+            Optional explicit list of numbers to include. By default the
+            loaded prime set is used.
+        """
+
+        if numbers is None:
+            numbers = sorted(self.prime_set)
+
+        df = generate_prefix_suffix_matrix(numbers, prefix_digits, suffix_digits)
+
         return df
 
     def show_sample_data(self, df, title, max_rows=5):

--- a/src/utils/prefix_suffix_utils.py
+++ b/src/utils/prefix_suffix_utils.py
@@ -1,0 +1,66 @@
+"""Utility functions for prefix-suffix matrix generation."""
+
+from typing import Iterable, List
+
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - optional dependency
+    pd = None
+
+
+def generate_prefix_suffix_matrix(
+    numbers: Iterable[int], prefix_digits: int, suffix_digits: int
+) -> "pd.DataFrame":
+    """Create a prefix-suffix matrix from a collection of numbers.
+
+    Each number is split into ``prefix_digits`` leading digits and
+    ``suffix_digits`` trailing digits. The matrix contains a 1 when the
+    combination ``prefix`` + ``suffix`` exists in ``numbers`` and 0 otherwise.
+
+    Parameters
+    ----------
+    numbers:
+        Iterable of integers to place in the matrix.
+    prefix_digits:
+        How many leading digits to use for the prefix (row index).
+    suffix_digits:
+        How many trailing digits to use for the suffix (column label).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Binary matrix indexed by prefixes with suffix columns.
+    """
+
+    if pd is None:
+        raise ImportError("pandas is required for generate_prefix_suffix_matrix")
+
+    if prefix_digits <= 0 or suffix_digits <= 0:
+        raise ValueError("prefix_digits and suffix_digits must be positive")
+
+    prefixes: set[int] = set()
+    suffixes: set[int] = set()
+    entries: List[tuple[int, int]] = []
+
+    for number in numbers:
+        s = str(number)
+        if len(s) < prefix_digits + suffix_digits:
+            continue
+        prefix = int(s[:prefix_digits])
+        suffix = int(s[-suffix_digits:])
+        prefixes.add(prefix)
+        suffixes.add(suffix)
+        entries.append((prefix, suffix))
+
+    prefix_list = sorted(prefixes)
+    suffix_list = sorted(suffixes)
+    df = pd.DataFrame(
+        0, index=prefix_list, columns=[str(s) for s in suffix_list]
+    )
+    df.index.name = f"prefix_{prefix_digits}d"
+    df.columns.name = f"suffix_{suffix_digits}d"
+
+    for prefix, suffix in entries:
+        df.loc[prefix, str(suffix)] = 1
+
+    return df


### PR DESCRIPTION
## Summary
- add new utility `generate_prefix_suffix_matrix` for flexible prefix/suffix analysis
- integrate helper into `PrimeCSVGenerator`
- document helper in API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcc34a620832ca1cf63a967f6ab7d