### PR TITLE
Add set distance and polynomial residual features

### DIFF
--- a/tests/test_utils/test_math_utils.py
+++ b/tests/test_utils/test_math_utils.py
@@ -1,5 +1,10 @@
 import numpy as np
-from src.utils.math_utils import generate_mathematical_features
+from src.utils.math_utils import (
+    generate_mathematical_features,
+    distance_to_next,
+    distance_to_prev,
+    fit_polynomial_features,
+)
 
 
 def test_diff_ratio_sliding_and_digit_tensor():
@@ -19,3 +24,22 @@ def test_defaults_without_history():
     assert "ratio_n" in features and features["ratio_n"] == 0
     assert "mean_last_5" in features
     assert "std_last_5" in features
+
+
+def test_distance_helpers_and_polyfit():
+    num_set = {2, 5, 10}
+    assert distance_to_next(4, num_set) == 1
+    assert distance_to_prev(4, num_set) == 2
+    assert distance_to_next(10, num_set) == 0
+    assert distance_to_prev(2, num_set) == 0
+
+    residuals = fit_polynomial_features(1234, degree=1)
+    assert isinstance(residuals, list)
+    assert len(residuals) == 4
+
+    features = generate_mathematical_features(
+        6, reference_set=num_set, poly_degree=2
+    )
+    assert features["dist_to_next"] == 4
+    assert features["dist_to_prev"] == 1
+    assert "poly_deg_2_residuals" in features


### PR DESCRIPTION
## Summary
- implement `distance_to_next` and `distance_to_prev` helpers
- implement polynomial residual calculation
- integrate optional distance and polynomial features into `generate_mathematical_features`
- test new utilities and optional features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcd76fa1c832ca546a0d4ad2483f8