### PR TITLE
Update docs for UniversalMathDiscovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,13 +13,13 @@ Welcome to the documentation for the Mathematical Pattern Discovery Engine.
 ## Quick Start
 
 ```python
-from math_discovery.core import discovery_engine
+from math_discovery.core.discovery_engine import UniversalMathDiscovery
 
 # Initialize the discovery engine
-engine = discovery_engine.DiscoveryEngine()
+engine = UniversalMathDiscovery(lambda n: n % 2 == 0, "Even Numbers")
 
 # Analyze a mathematical sequence
-results = engine.discover_patterns([2, 3, 5, 7, 11, 13, 17, 19, 23])
+results = engine.run_complete_discovery()
 ```
 
 ## Project Structure
@@ -31,3 +31,9 @@ The project is organized into several key modules:
 - `analyzers/` - Specialized mathematical analyzers
 - `utils/` - Utility functions and helpers
 - `cli/` - Command-line interfaces
+
+## New Capabilities
+
+- Difference and ratio-based features for sequence analysis
+- Prefix–suffix dataset generation utilities
+- Optional Fourier or PCA embeddings of digit sequences

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -5,25 +5,32 @@
 ### discovery_engine
 
 Main discovery engine for pattern analysis.
+Supports difference/ratio features and optional Fourier or PCA embeddings of
+digit sequences.
 
 ```python
-class DiscoveryEngine:
-    def __init__(self, config_path=None):
+class UniversalMathDiscovery:
+    def __init__(
+        self,
+        target_function,
+        function_name,
+        max_number=100000,
+        embedding=None,
+        embedding_components=None,
+    ):
         """Initialize the discovery engine."""
-        pass
-    
-    def discover_patterns(self, sequence):
-        """Discover patterns in a mathematical sequence."""
-        pass
-    
-    def predict_next_terms(self, sequence, n_terms=5):
-        """Predict the next n terms in a sequence."""
-        pass
+        ...
+
+    def run_complete_discovery(self):
+        """Run training and analysis on the target function."""
+        ...
 ```
 
 ### feature_extractor
 
-Mathematical feature extraction utilities.
+Mathematical feature extraction utilities. When previous numbers are supplied,
+the extractor computes difference and ratio features and sliding window
+statistics.
 
 ```python
 class FeatureExtractor:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -5,14 +5,13 @@
 ### Basic Usage
 
 ```python
-from math_discovery.core import discovery_engine
+from math_discovery.core.discovery_engine import UniversalMathDiscovery
 
 # Create discovery engine
-engine = discovery_engine.DiscoveryEngine()
+engine = UniversalMathDiscovery(lambda n: n in [2, 3, 5, 7, 11, 13], "Primes")
 
 # Analyze prime numbers
-primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
-patterns = engine.discover_patterns(primes)
+patterns = engine.run_complete_discovery()
 ```
 
 ### Command Line Interface
@@ -35,3 +34,12 @@ The system uses YAML configuration files in the `configs/` directory:
 - `default_config.yaml` - General settings
 - `prime_config.yaml` - Prime number analysis
 - `oeis_config.yaml` - OEIS sequence analysis
+
+## New Capabilities
+
+- Difference and ratio features automatically computed when a history is
+  provided.
+- `PrimeCSVGenerator.generate_prefix_suffix_dataset` creates custom
+  prefix–suffix matrices for training.
+- Use `embedding="fourier"` or `embedding="pca"` in `UniversalMathDiscovery`
+  to embed digit patterns before model training.


### PR DESCRIPTION
## Summary
- update docs to use `UniversalMathDiscovery` instead of `DiscoveryEngine`
- document new capabilities like difference/ratio features, prefix–suffix dataset generation and Fourier/PCA embeddings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd4d36770832cbe48c29da33f6b49